### PR TITLE
fill ImageConfig on init

### DIFF
--- a/lambroll.go
+++ b/lambroll.go
@@ -266,6 +266,20 @@ func newFunctionFrom(c *lambda.FunctionConfiguration, code *lambda.FunctionCodeL
 			Variables: e.Variables,
 		}
 	}
+	if i := c.ImageConfigResponse.ImageConfig; i != nil {
+		if *i.WorkingDirectory != "" {
+			fn.ImageConfig = &lambda.ImageConfig{
+				Command:          i.Command,
+				EntryPoint:       i.EntryPoint,
+				WorkingDirectory: i.WorkingDirectory,
+			}
+		} else {
+			fn.ImageConfig = &lambda.ImageConfig{
+				Command:    i.Command,
+				EntryPoint: i.EntryPoint,
+			}
+		}
+	}
 	for _, layer := range c.Layers {
 		fn.Layers = append(fn.Layers, layer.Arn)
 	}


### PR DESCRIPTION
`function.json` created by `lambda init` is missing `ImageConfig` field. This patch fills it.

I referred to [documentation of AWS Lambda `GetFunction` Response Syntax](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html).

Ref PR: https://github.com/fujiwara/lambroll/pull/101

Thank you!